### PR TITLE
Add ability to hide stories/notes tray in inbox in Facebook Messenger

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/messenger/inbox/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/messenger/inbox/Fingerprints.kt
@@ -38,3 +38,8 @@ internal object LoadInboxAdsFingerprint : Fingerprint(
             "InboxAdsItemSupplierImplementation;"
     },
 )
+
+internal object FriendsInboxTrayFingerprint : Fingerprint(
+    returnType = "Z",
+    strings = listOf("com.facebook.messaging.friendsinboxunit.plugins.inboxunit.FriendsInboxUnitKillSwitch"),
+)

--- a/patches/src/main/kotlin/app/morphe/patches/messenger/inbox/HideInboxStoriesNotesTrayPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/messenger/inbox/HideInboxStoriesNotesTrayPatch.kt
@@ -1,0 +1,20 @@
+package app.morphe.patches.messenger.inbox
+
+import app.morphe.patches.shared.compat.AppCompatibilities
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+
+@Suppress("unused")
+val hideInboxStoriesNotesTrayPatch = bytecodePatch(
+    name = "Hide inbox stories and notes tray",
+    description = "Hides the stories and notes horizontal tray at the top of the inbox.",
+) {
+    compatibleWith(AppCompatibilities.MESSENGER)
+
+    execute {
+        FriendsInboxTrayFingerprint.method.addInstructions(0, """
+            const/4 v0, 0x0
+            return v0
+        """)
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/messenger/inbox/HideInboxStoriesNotesTrayPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/messenger/inbox/HideInboxStoriesNotesTrayPatch.kt
@@ -12,9 +12,12 @@ val hideInboxStoriesNotesTrayPatch = bytecodePatch(
     compatibleWith(AppCompatibilities.MESSENGER)
 
     execute {
-        FriendsInboxTrayFingerprint.method.addInstructions(0, """
-            const/4 v0, 0x0
-            return v0
-        """)
+        FriendsInboxTrayFingerprint.method.addInstructions(
+            0,
+            """
+                const/4 v0, 0x0
+                return v0
+            """.trimIndent()
+        )
     }
 }


### PR DESCRIPTION
### Description

Add ability to hide stories/notes tray in inbox in Facebook Messenger. This is the tray that is above all the chats in the main inbox. I've always hated it and it always shows people I never message, so thought I'd come up with a patch for it!

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
I tested it on v552.0.0.44.65 since that is the highest version that is supported by the "inbox ads" patch

- [ ] Tested on **experimental** supported versions (Optional)
