### PR TITLE
feat(amznmusic): add Rename shared permissions patch

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
 plugins {
     alias(libs.plugins.android.library) apply false
 }
+

--- a/patches/src/main/kotlin/app/morphe/patches/amznmusic/misc/permissions/RenameSharedPermissionsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/amznmusic/misc/permissions/RenameSharedPermissionsPatch.kt
@@ -1,0 +1,49 @@
+/*
+ * Forked from:
+ * https://github.com/hoo-dles/morphe-patches/blob/main/patches/src/main/kotlin/hoodles/morphe/patches/primevideo/misc/permissions/RenameSharedPermissionsPatch.kt
+ */
+package app.morphe.patches.amznmusic.misc.permissions
+
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.patch.resourcePatch
+import app.morphe.util.asSequence
+import app.morphe.util.getNode
+import app.morphe.patches.shared.compat.AppCompatibilities
+import org.w3c.dom.Element
+
+@Suppress("unused")
+val renameSharedPermissionsPatch = resourcePatch(
+    name = "Rename shared permissions",
+    description = "Rename certain permissions shared across Amazon apps. " +
+            "Applying this patch can fix installation errors, but can also break features in certain apps.",
+) {
+    compatibleWith(AppCompatibilities.AMAZON_MUSIC)
+
+    val permissionNames = setOf(
+    "com.amazon.identity.permission.CAN_CALL_MAP_INFORMATION_PROVIDER",
+    "com.amazon.identity.auth.device.perm.AUTH_SDK",
+    "com.amazon.dcp.sso.permission.account.changed",
+    "com.amazon.dcp.sso.permission.AmazonAccountPropertyService.property.changed",
+    "com.amazon.identity.permission.CALL_AMAZON_DEVICE_INFORMATION_PROVIDER",
+    "com.amazon.appmanager.preload.permission.READ_PRELOAD_DEVICE_INFO_PROVIDER",
+    "com.amazon.CONTENT_PROVIDER_ACCESS",
+    "com.amazon.CONTENT_NOTIFICATION_ACCESS"
+)
+
+    execute {
+        document("AndroidManifest.xml").use { document ->
+            val manifest = document.getNode("manifest") as Element
+            val permissions = manifest
+                .getElementsByTagName("permission")
+                .asSequence()
+                .map { Pair(it as Element, it.getAttribute("android:name")) }
+                .filter { (_, name) -> name in permissionNames }
+
+            if (permissions.none()) throw PatchException("Could not find any permissions to rename")
+
+            permissions.forEach { (element, name) ->
+                element.setAttribute("android:name", "revanced.$name")
+            }
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/amznmusic/misc/permissions/RenameSharedPermissionsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/amznmusic/misc/permissions/RenameSharedPermissionsPatch.kt
@@ -15,7 +15,7 @@ import org.w3c.dom.Element
 val renameSharedPermissionsPatch = resourcePatch(
     name = "Rename shared permissions",
     description = "Rename certain permissions shared across Amazon apps. " +
-            "Applying this patch can fix installation errors, but can also break features in certain apps.",
+            "Applying this patch can fix installation errors, but can also break features in certain apps."
 ) {
     compatibleWith(AppCompatibilities.AMAZON_MUSIC)
 


### PR DESCRIPTION
### Description
Ports the "Rename shared permissions" patch from [hoo-dles/morphe-patches](https://github.com/hoo-dles/morphe-patches) to Amazon Music.

This patch renames permissions shared across Amazon apps (Music, Prime Video, Shopping) that cause `INSTALL_FAILED_DUPLICATE_PERMISSION` errors when trying to install multiple patched Amazon apps simultaneously.

The following permissions are renamed by adding the `revanced.` prefix:
- `com.amazon.identity.permission.CAN_CALL_MAP_INFORMATION_PROVIDER`
- `com.amazon.identity.auth.device.perm.AUTH_SDK`
- `com.amazon.dcp.sso.permission.account.changed`
- `com.amazon.dcp.sso.permission.AmazonAccountPropertyService.property.changed`
- `com.amazon.identity.permission.CALL_AMAZON_DEVICE_INFORMATION_PROVIDER`
- `com.amazon.appmanager.preload.permission.READ_PRELOAD_DEVICE_INFO_PROVIDER`
- `com.amazon.CONTENT_PROVIDER_ACCESS`
- `com.amazon.CONTENT_NOTIFICATION_ACCESS`

Closes #7
May also close #18 and other issues related to shared permission conflicts, though I was unable to verify those cases directly.

### Additional context
Tested with Amazon Music, Amazon Prime Video (patched with hoo-dles/morphe-patches), and Amazon Shopping all installed simultaneously.

### Test results
- [x] Tested on Amazon Music 26.22.1 

