### PR TITLE
build: update Morphe Patcher to 1.7.0

### DIFF
--- a/extensions/shared-youtube/build.gradle.kts
+++ b/extensions/shared-youtube/build.gradle.kts
@@ -7,6 +7,8 @@ extension {
 }
 
 android {
+    namespace = "app.morphe.extension.sharedyoutube"
+
     buildTypes {
         release {
             // 'libj2v8.so' is already included in the patch.

--- a/extensions/shared-youtube/library/build.gradle.kts
+++ b/extensions/shared-youtube/library/build.gradle.kts
@@ -1,10 +1,9 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.protobuf)
 }
 
 android {
-    namespace = "app.morphe.extension"
+    namespace = "app.morphe.extension.sharedyoutube.library"
     compileSdk = 35
 
     defaultConfig {
@@ -21,25 +20,8 @@ dependencies {
     compileOnly(libs.annotation)
 
     implementation(libs.gson)
-    implementation(libs.protobuf.javalite)
-
     //noinspection UseTomlInstead
     implementation("com.github.ynab:J2V8:6.2.1-16kb.2@aar")
 
     implementation(project(":extensions:shared:library"))
-}
-
-protobuf {
-    protoc {
-        artifact = libs.protobuf.protoc.get().toString()
-    }
-    generateProtoTasks {
-        all().forEach { task ->
-            task.builtins {
-                create("java") {
-                    option("lite")
-                }
-            }
-        }
-    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,14 @@
 [versions]
 # Align with morphe-patches-template (Compatibility / Manager display names).
-morphe-patcher = "1.3.3"
+morphe-patcher = "1.7.0"
 # Tracking https://github.com/google/smali/issues/100.
-smali = "b6365a84f4"
-agp = "8.2.2"
+smali = "d92701d947"
 annotation = "1.9.1"
 androidx-core = "1.16.0"
 gson = "2.13.2"
 guava = "33.5.0-jre"
 hiddenapi = "6.1"
 okhttp = "4.12.0"
-protobuf = "0.9.5"
-protoc = "3.25.2"
 
 [libraries]
 morphe-patcher = { module = "app.morphe:morphe-patcher", version.ref = "morphe-patcher" }
@@ -21,9 +18,6 @@ gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 hiddenapi = { module = "org.lsposed.hiddenapibypass:hiddenapibypass", version.ref = "hiddenapi" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
-protobuf-javalite = { module = "com.google.protobuf:protobuf-javalite", version.ref = "protoc" }
-protobuf-protoc = { module = "com.google.protobuf:protoc", version.ref = "protoc" }
 
 [plugins]
 android-library = { id = "com.android.library" }
-protobuf = { id = "com.google.protobuf", version.ref = "protobuf" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,10 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=f1771298a70f6db5a29daf62378c4e18a17fc33c9ba6b14362e0cdf40610380d
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
+distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
+retries=0
+retryBackOffMs=500
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,7 +20,7 @@ pluginManagement {
 }
 
 plugins {
-    id("app.morphe.patches") version "1.2.0"
+    id("app.morphe.patches") version "1.3.3"
 }
 
 settings {


### PR DESCRIPTION
## What changed

- Update Morphe Patcher to 1.7.0
- Align the Gradle plugin, wrapper, and Smali versions with the current Morphe template
- Add the namespaces required by AGP 9
- Remove unused protobuf configuration

This keeps the patch bundle aligned with the current stable Morphe toolchain. No patch implementations are changed.

## Verification

- Built the patch bundle successfully
- Ran ktlint
