### PR TITLE
fix(Google Photos): Clone app-owned permissions

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/googlephotos/misc/gms/GmsCoreSupportPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/googlephotos/misc/gms/GmsCoreSupportPatch.kt
@@ -42,11 +42,11 @@ private object DummyPreferenceScreen : BasePreferenceScreen() {
     }
 }
 
-private fun gmsCoreSupportResourcePatch() =
+private fun gmsCoreSupportResourcePatch(appPermissionReplacements: MutableMap<String, String>) =
     app.morphe.patches.shared.misc.gms.gmsCoreSupportResourcePatch(
         fromPackageName = PHOTOS_PACKAGE_NAME,
         toPackageName = MORPHE_PHOTOS_PACKAGE_NAME,
         spoofedPackageSignature = "24bb24c05e47e0aefa68a58a766179d9b613a600",
         screen = DummyPreferenceScreen.SCREEN,
+        appPermissionReplacements = appPermissionReplacements,
     )
-

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/gms/GmsCoreSupportPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/gms/GmsCoreSupportPatch.kt
@@ -22,6 +22,7 @@ import app.morphe.patches.shared.misc.gms.Constants.AUTHORITIES
 import app.morphe.patches.shared.misc.gms.Constants.PERMISSIONS
 import app.morphe.patches.shared.misc.settings.preference.BasePreferenceScreen
 import app.morphe.patches.shared.misc.settings.preference.IntentPreference
+import app.morphe.util.asSequence
 import app.morphe.util.findMutableMethodOf
 import app.morphe.util.getReference
 import app.morphe.util.returnEarly
@@ -62,7 +63,7 @@ fun gmsCoreSupportPatch(
     earlyReturnFingerprints: Set<Fingerprint> = setOf(),
     mainActivityOnCreateFingerprint: Fingerprint,
     extensionPatch: Patch<*>,
-    gmsCoreSupportResourcePatchFactory: () -> Patch<*>,
+    gmsCoreSupportResourcePatchFactory: (MutableMap<String, String>) -> Patch<*>,
     executeBlock: BytecodePatchContext.() -> Unit = {},
     block: BytecodePatchBuilder.() -> Unit = {},
 ) = bytecodePatch(
@@ -71,9 +72,11 @@ fun gmsCoreSupportPatch(
         "using a GmsCore instead of Google Play Services.",
 ) {
 
+    val appPermissionReplacements = mutableMapOf<String, String>()
+
     dependsOn(
         changePackageNamePatch,
-        gmsCoreSupportResourcePatchFactory(),
+        gmsCoreSupportResourcePatchFactory(appPermissionReplacements),
         extensionPatch,
     )
 
@@ -117,7 +120,7 @@ fun gmsCoreSupportPatch(
             in PERMISSIONS,
             in ACTIONS,
             in AUTHORITIES,
-            -> referencedString.replace("com.google", GMS_CORE_VENDOR_GROUP_ID)
+                -> referencedString.replace("com.google", GMS_CORE_VENDOR_GROUP_ID)
 
             // No vendor prefix for whatever reason...
             "subscribedfeeds" -> "$GMS_CORE_VENDOR_GROUP_ID.subscribedfeeds"
@@ -148,11 +151,13 @@ fun gmsCoreSupportPatch(
             return null
         }
 
+        fun appPermissionTransform(string: String): String? = appPermissionReplacements[string]
+
         fun packageNameTransform(fromPackageName: String, toPackageName: String): (String) -> String? = { string ->
             when (string) {
                 "$fromPackageName.SuggestionProvider",
                 "$fromPackageName.fileprovider",
-                -> string.replace(fromPackageName, toPackageName)
+                    -> string.replace(fromPackageName, toPackageName)
 
                 else -> null
             }
@@ -179,6 +184,7 @@ fun gmsCoreSupportPatch(
 
         // Transform all strings using all provided transforms, first match wins.
         val transformations = arrayOf(
+            ::appPermissionTransform,
             ::commonTransform,
             ::contentUrisTransform,
             packageNameTransform(fromPackageName, packageName),
@@ -515,6 +521,7 @@ fun gmsCoreSupportResourcePatch(
     toPackageName: String,
     spoofedPackageSignature: String,
     screen: BasePreferenceScreen.Screen,
+    appPermissionReplacements: MutableMap<String, String>,
     executeBlock: ResourcePatchContext.() -> Unit = {},
     block: ResourcePatchBuilder.() -> Unit = {},
 ) = resourcePatch {
@@ -571,8 +578,6 @@ fun gmsCoreSupportResourcePatch(
             val transformations = mapOf(
                 "package=\"$fromPackageName" to "package=\"$packageName",
                 "android:authorities=\"$fromPackageName" to "android:authorities=\"$packageName",
-                "$fromPackageName.permission.C2D_MESSAGE" to "$packageName.permission.C2D_MESSAGE",
-                "$fromPackageName.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION" to "$packageName.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION",
                 "com.google.android.c2dm" to "$GMS_CORE_VENDOR_GROUP_ID.android.c2dm",
                 "com.google.android.libraries.photos.api.mars" to "$GMS_CORE_VENDOR_GROUP_ID.android.apps.photos.api.mars",
                 "</queries>" to "<package android:name=\"$GMS_CORE_VENDOR_GROUP_ID.android.gms\"/></queries>",
@@ -587,6 +592,47 @@ fun gmsCoreSupportResourcePatch(
                     )
                 },
             )
+
+            document("AndroidManifest.xml").use { document ->
+                appPermissionReplacements.clear()
+
+                fun clonePermissionName(permissionName: String) = when {
+                    permissionName.startsWith("$fromPackageName.") -> permissionName.replaceFirst(
+                        fromPackageName, packageName
+                    )
+
+                    permissionName.startsWith(".") -> "$packageName$permissionName"
+                    else -> "$packageName.$permissionName"
+                }
+
+                document.getElementsByTagName("permission").asSequence().map { it as Element }.forEach { permission ->
+                    val oldName = permission.getAttribute("android:name")
+                    val newName = clonePermissionName(oldName)
+
+                    appPermissionReplacements[oldName] = newName
+                    permission.setAttribute("android:name", newName)
+                }
+
+                sequenceOf("uses-permission", "uses-permission-sdk-23").flatMap {
+                    document.getElementsByTagName(it).asSequence()
+                }.map { it as Element }.forEach { permission ->
+                    val oldName = permission.getAttribute("android:name")
+                    appPermissionReplacements[oldName]?.let { permission.setAttribute("android:name", it) }
+                }
+
+                val permissionAttributes = arrayOf(
+                    "android:permission",
+                    "android:readPermission",
+                    "android:writePermission",
+                )
+
+                document.getElementsByTagName("*").asSequence().map { it as Element }.forEach { element ->
+                    permissionAttributes.forEach { attribute ->
+                        val oldName = element.getAttribute(attribute)
+                        appPermissionReplacements[oldName]?.let { element.setAttribute(attribute, it) }
+                    }
+                }
+            }
         }
 
         patchManifest()


### PR DESCRIPTION
### Description

Google Photos 7.88+ declares additional app-owned permissions such as `com.google.android.apps.photos.permission.SEARCH_IN_PHOTOS`.

The GmsCore resource patch currently renames only two known app permissions, so the cloned package can retain a permission declaration already owned by the stock Google Photos package. Android then rejects installation with `INSTALL_FAILED_DUPLICATE_PERMISSION`.

This change derives permission replacements from the target manifest instead:

- discover permissions declared by the app
- rename them into the cloned package namespace
- update corresponding manifest permission references
- update exact bytecode string references
- replace the existing hard-coded handling for `C2D_MESSAGE` and `DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION`

The replacement map is scoped to the GmsCore patch instance rather than stored as shared global state.

- Closes #107

### Additional context

The issue is reproducible with Google Photos 7.88+ because it declares `com.google.android.apps.photos.permission.SEARCH_IN_PHOTOS`. while 7.87 doesn't and thus installs successfully alongside the stock app.

### Test results

- [X] Patched Google Photos 7.89.0.968035987 successfully
- [X] Installed alongside stock Google Photos successfully
- [X] Google account selection persists after cold start
- [X] Backup initializes successfully
- [X] Spoof remains active
- [X] Basic photo browsing/editing works
- [ ] ~Tested on both the **minimum** and **maximum** supported versions~ N/A
- [ ] ~Tested on **experimental** supported versions (Optional)~ N/A
