### PR TITLE
bump(Strava): Add support for `477.14`

### DIFF
--- a/extensions/strava/src/main/java/app/morphe/extension/strava/AddMediaDownloadPatch.java
+++ b/extensions/strava/src/main/java/app/morphe/extension/strava/AddMediaDownloadPatch.java
@@ -95,7 +95,7 @@ public final class AddMediaDownloadPatch {
                     values.put(MediaStore.Images.Media.IS_PENDING, 0);
                     resolver.update(row, values, null);
                 }
-                showInfoToast("yis_2024_local_save_image_success", "✔️");
+                showInfoToast("animated_content_save_image_success", "✔️");
             } catch (IOException e) {
                 showErrorToast("download_failure", "❌", e);
             }
@@ -156,7 +156,7 @@ public final class AddMediaDownloadPatch {
                     values.put(MediaStore.Video.Media.IS_PENDING, 0);
                     resolver.update(row, values, null);
                 }
-                showInfoToast("yis_2024_local_save_video_success", "✔️");
+                showInfoToast("animated_content_save_video_success", "✔️");
             } catch (IOException e) {
                 showErrorToast("download_failure", "❌", e);
             }

--- a/extensions/strava/src/main/java/app/morphe/extension/strava/GiveKudosOnClickListener.java
+++ b/extensions/strava/src/main/java/app/morphe/extension/strava/GiveKudosOnClickListener.java
@@ -15,6 +15,25 @@ public final class GiveKudosOnClickListener implements View.OnClickListener {
         this.handlerMethodName = handlerMethodName;
     }
 
+    /**
+     * Attaches a listener to the "Give Kudos" button.
+     *
+     * <p>Called instead of setting the listener in patched code, because the constructor
+     * this is injected into has too few free registers to do so inline.
+     * Using {@link View#setOnClickListener} also avoids depending on the button's own type,
+     * which overrides that method to forward clicks into its Compose content.
+     *
+     * @param view              The "Give Kudos" button, or {@code null} if it is not in the layout.
+     * @param outerThis         Instance declaring {@code handlerMethodName}.
+     * @param actionSingleton   Singleton state that makes the handler show the "Give Kudos" dialog.
+     * @param handlerMethodName Name of the method that handles the state.
+     */
+    public static void attach(View view, Object outerThis, Object actionSingleton, String handlerMethodName) {
+        if (view == null) return;
+
+        view.setOnClickListener(new GiveKudosOnClickListener(outerThis, actionSingleton, handlerMethodName));
+    }
+
     @Override
     public void onClick(View v) {
         if (outerThis == null || actionSingleton == null || handlerMethodName == null) return;
@@ -33,7 +52,7 @@ public final class GiveKudosOnClickListener implements View.OnClickListener {
             target.setAccessible(true);
             target.invoke(outerThis, actionSingleton);
         } catch (Throwable ignored) {
-            // Best-effort: if Tumblr/Strava internals change, avoid crashing the app.
+            // Best-effort: if Strava internals change, avoid crashing the app.
         }
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
@@ -157,7 +157,7 @@ internal object AppCompatibilities {
         name = "Strava",
         packageName = "com.strava",
         appIconColor = 0xFC6925,
-        targets = listOf(AppTarget("473.11"))
+        targets = listOf(AppTarget("477.14"))
     )
 
     val TWITCH = Compatibility(

--- a/patches/src/main/kotlin/app/morphe/patches/strava/groupkudos/AddGiveGroupKudosButtonToGroupActivity.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/strava/groupkudos/AddGiveGroupKudosButtonToGroupActivity.kt
@@ -7,12 +7,11 @@ package app.morphe.patches.strava.groupkudos
 import app.morphe.patches.shared.compat.AppCompatibilities
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
-import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.strava.misc.extension.sharedExtensionPatch
 import app.morphe.util.childElementsSequence
-import app.morphe.util.containsLiteralInstruction
 import app.morphe.util.findElementByAttributeValueOrThrow
 import app.morphe.util.getFreeRegisterProvider
 import app.morphe.util.getReference
@@ -27,7 +26,7 @@ private const val GIVE_KUDOS_ON_CLICK_LISTENER_DESCRIPTOR =
 private const val ATTACH_LISTENER_METHOD_DESCRIPTOR = "$GIVE_KUDOS_ON_CLICK_LISTENER_DESCRIPTOR->" +
     "attach(Landroid/view/View;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;)V"
 
-private var shakeToKudosStringId = -1
+internal var shakeToKudosStringId = -1
 private var kudosIdId = -1
 private var leaveIdId = -1
 
@@ -103,20 +102,11 @@ val addGiveGroupKudosButtonToGroupActivity = bytecodePatch(
     dependsOn(addGiveKudosButtonToLayoutPatch, sharedExtensionPatch)
 
     execute {
-        val viewDelegateClassDef = InitFingerprint.originalClassDef
-
-        // Method that renders the view states, one of which shows the "Give Kudos" dialog.
-        // Cannot be matched on the Kotlin parameter null check string "state",
-        // because the app no longer contains those strings.
-        val actionHandlerMethod = viewDelegateClassDef.methods.firstOrNull { method ->
-            method.containsLiteralInstruction(shakeToKudosStringId.toLong())
-        } ?: throw PatchException(
-            "Could not find the method that shows the 'Give Kudos' dialog in: ${viewDelegateClassDef.type}"
-        )
+        val actionHandlerMatch = ActionHandlerFingerprint.match(InitFingerprint.originalClassDef)
 
         // Singleton instance of the state that makes the action handler show the "Give Kudos" dialog.
-        val giveKudosStateReference = actionHandlerMethod.implementation!!.instructions
-            .take(actionHandlerMethod.indexOfFirstLiteralInstructionOrThrow(shakeToKudosStringId.toLong()))
+        val giveKudosStateReference = actionHandlerMatch.method.instructions
+            .take(actionHandlerMatch.instructionMatches.first().index)
             .last { instruction -> instruction.opcode == Opcode.SGET_OBJECT }
             .getReference<FieldReference>()!!
 
@@ -140,7 +130,7 @@ val addGiveGroupKudosButtonToGroupActivity = bytecodePatch(
                     ${findViewByIdInstruction.opcode.name} { v$fragmentRegister, v$viewRegister }, ${findViewByIdInstruction.reference}
                     move-result-object v$viewRegister
                     sget-object v$stateRegister, $giveKudosStateReference
-                    const-string v$methodNameRegister, "${actionHandlerMethod.name}"
+                    const-string v$methodNameRegister, "${actionHandlerMatch.method.name}"
                     invoke-static { v$viewRegister, p0, v$stateRegister, v$methodNameRegister }, $ATTACH_LISTENER_METHOD_DESCRIPTOR
                 """.trimIndent(),
             )

--- a/patches/src/main/kotlin/app/morphe/patches/strava/groupkudos/AddGiveGroupKudosButtonToGroupActivity.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/strava/groupkudos/AddGiveGroupKudosButtonToGroupActivity.kt
@@ -1,20 +1,24 @@
 /*
+ * Copyright 2026 De-Vanced
+ * https://github.com/RookieEnough/De-Vanced/pull/113
+ *
  * Forked from:
  * https://gitlab.com/ReVanced/revanced-patches/-/blob/main/patches/src/main/kotlin/app/revanced/patches/strava/groupkudos/AddGiveGroupKudosButtonToGroupActivity.kt
  */
 package app.morphe.patches.strava.groupkudos
 
-import app.morphe.patches.shared.compat.AppCompatibilities
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
-import app.morphe.patcher.extensions.InstructionExtensions.instructions
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
+import app.morphe.patches.shared.compat.AppCompatibilities
+import app.morphe.patches.shared.misc.mapping.resourceMappingPatch
 import app.morphe.patches.strava.misc.extension.sharedExtensionPatch
 import app.morphe.util.childElementsSequence
 import app.morphe.util.findElementByAttributeValueOrThrow
 import app.morphe.util.getFreeRegisterProvider
 import app.morphe.util.getReference
+import app.morphe.util.indexOfFirstInstructionReversedOrThrow
 import app.morphe.util.indexOfFirstLiteralInstructionOrThrow
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction35c
@@ -26,7 +30,6 @@ private const val GIVE_KUDOS_ON_CLICK_LISTENER_DESCRIPTOR =
 private const val ATTACH_LISTENER_METHOD_DESCRIPTOR = "$GIVE_KUDOS_ON_CLICK_LISTENER_DESCRIPTOR->" +
     "attach(Landroid/view/View;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;)V"
 
-internal var shakeToKudosStringId = -1
 private var kudosIdId = -1
 private var leaveIdId = -1
 
@@ -34,6 +37,7 @@ private val addGiveKudosButtonToLayoutPatch = resourcePatch {
     fun String.toResourceId() = substring(2).toInt(16)
 
     execute {
+
         document("res/values/public.xml").use { public ->
             fun Sequence<Element>.firstByName(name: String) = first {
                 it.getAttribute("name") == name
@@ -45,12 +49,6 @@ private val addGiveKudosButtonToLayoutPatch = resourcePatch {
             val idElements = publicElements.filter {
                 it.getAttribute("type") == "id"
             }
-            val stringElements = publicElements.filter {
-                it.getAttribute("type") == "string"
-            }
-
-            shakeToKudosStringId =
-                stringElements.firstByName("shake_to_kudos_dialog_title").getAttribute("id").toResourceId()
 
             val kudosIdNode = idElements.firstByName("kudos").apply {
                 kudosIdId = getAttribute("id").toResourceId()
@@ -99,16 +97,21 @@ val addGiveGroupKudosButtonToGroupActivity = bytecodePatch(
 ) {
     compatibleWith(AppCompatibilities.STRAVA)
 
-    dependsOn(addGiveKudosButtonToLayoutPatch, sharedExtensionPatch)
+    dependsOn(
+        sharedExtensionPatch,
+        resourceMappingPatch,
+        addGiveKudosButtonToLayoutPatch
+    )
 
     execute {
-        val actionHandlerMatch = ActionHandlerFingerprint.match(InitFingerprint.originalClassDef)
-
         // Singleton instance of the state that makes the action handler show the "Give Kudos" dialog.
-        val giveKudosStateReference = actionHandlerMatch.method.instructions
-            .take(actionHandlerMatch.instructionMatches.first().index)
-            .last { instruction -> instruction.opcode == Opcode.SGET_OBJECT }
-            .getReference<FieldReference>()!!
+        val actionHandlerMethodName = ActionHandlerFingerprint.method.name
+        // Find last SGET_OBJECT reference
+        val giveKudosStateReference = ActionHandlerFingerprint.method.let {
+            it.getInstruction(
+                it.indexOfFirstInstructionReversedOrThrow(Opcode.SGET_OBJECT)
+            ).getReference<FieldReference>()!!
+        }
 
         InitFingerprint.method.apply {
             // Instructions that inflate the "Leave Group" button, which the "Give Kudos" button is cloned from.
@@ -130,9 +133,9 @@ val addGiveGroupKudosButtonToGroupActivity = bytecodePatch(
                     ${findViewByIdInstruction.opcode.name} { v$fragmentRegister, v$viewRegister }, ${findViewByIdInstruction.reference}
                     move-result-object v$viewRegister
                     sget-object v$stateRegister, $giveKudosStateReference
-                    const-string v$methodNameRegister, "${actionHandlerMatch.method.name}"
+                    const-string v$methodNameRegister, "$actionHandlerMethodName"
                     invoke-static { v$viewRegister, p0, v$stateRegister, v$methodNameRegister }, $ATTACH_LISTENER_METHOD_DESCRIPTOR
-                """.trimIndent(),
+                """
             )
         }
     }

--- a/patches/src/main/kotlin/app/morphe/patches/strava/groupkudos/AddGiveGroupKudosButtonToGroupActivity.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/strava/groupkudos/AddGiveGroupKudosButtonToGroupActivity.kt
@@ -7,33 +7,25 @@ package app.morphe.patches.strava.groupkudos
 import app.morphe.patches.shared.compat.AppCompatibilities
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
-import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
-import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
 import app.morphe.patches.strava.misc.extension.sharedExtensionPatch
 import app.morphe.util.childElementsSequence
+import app.morphe.util.containsLiteralInstruction
 import app.morphe.util.findElementByAttributeValueOrThrow
+import app.morphe.util.getFreeRegisterProvider
 import app.morphe.util.getReference
-import com.android.tools.smali.dexlib2.AccessFlags
+import app.morphe.util.indexOfFirstLiteralInstructionOrThrow
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
-import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction11x
-import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction21c
-import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction31i
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction35c
-import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
-import com.android.tools.smali.dexlib2.iface.reference.TypeReference
-import com.android.tools.smali.dexlib2.immutable.ImmutableClassDef
-import com.android.tools.smali.dexlib2.immutable.ImmutableField
-import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
-import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import org.w3c.dom.Element
 
-private const val VIEW_CLASS_DESCRIPTOR = "Landroid/view/View;"
-private const val ON_CLICK_LISTENER_CLASS_DESCRIPTOR = "Landroid/view/View\$OnClickListener;"
 private const val GIVE_KUDOS_ON_CLICK_LISTENER_DESCRIPTOR =
     "Lapp/morphe/extension/strava/GiveKudosOnClickListener;"
+private const val ATTACH_LISTENER_METHOD_DESCRIPTOR = "$GIVE_KUDOS_ON_CLICK_LISTENER_DESCRIPTOR->" +
+    "attach(Landroid/view/View;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;)V"
 
 private var shakeToKudosStringId = -1
 private var kudosIdId = -1
@@ -111,45 +103,47 @@ val addGiveGroupKudosButtonToGroupActivity = bytecodePatch(
     dependsOn(addGiveKudosButtonToLayoutPatch, sharedExtensionPatch)
 
     execute {
-        val className = InitFingerprint.originalClassDef.type
-        val actionHandlerMethod = ActionHandlerFingerprint.match(InitFingerprint.originalClassDef).method
+        val viewDelegateClassDef = InitFingerprint.originalClassDef
 
-        val constShakeToKudosStringIndex = actionHandlerMethod.instructions.indexOfFirst {
-            it is NarrowLiteralInstruction && it.narrowLiteral == shakeToKudosStringId
-        }
-        val getSingletonInstruction =
-            actionHandlerMethod.instructions.filterIsInstance<BuilderInstruction21c>().last {
-                it.opcode == Opcode.SGET_OBJECT && it.location.index < constShakeToKudosStringIndex
-            }
+        // Method that renders the view states, one of which shows the "Give Kudos" dialog.
+        // Cannot be matched on the Kotlin parameter null check string "state",
+        // because the app no longer contains those strings.
+        val actionHandlerMethod = viewDelegateClassDef.methods.firstOrNull { method ->
+            method.containsLiteralInstruction(shakeToKudosStringId.toLong())
+        } ?: throw PatchException(
+            "Could not find the method that shows the 'Give Kudos' dialog in: ${viewDelegateClassDef.type}"
+        )
+
+        // Singleton instance of the state that makes the action handler show the "Give Kudos" dialog.
+        val giveKudosStateReference = actionHandlerMethod.implementation!!.instructions
+            .take(actionHandlerMethod.indexOfFirstLiteralInstructionOrThrow(shakeToKudosStringId.toLong()))
+            .last { instruction -> instruction.opcode == Opcode.SGET_OBJECT }
+            .getReference<FieldReference>()!!
 
         InitFingerprint.method.apply {
-            val constLeaveIdInstruction = instructions.filterIsInstance<BuilderInstruction31i>().first {
-                it.narrowLiteral == leaveIdId
-            }
-            val findViewByIdInstruction =
-                getInstruction<BuilderInstruction35c>(constLeaveIdInstruction.location.index + 1)
-            val moveViewInstruction =
-                getInstruction<BuilderInstruction11x>(constLeaveIdInstruction.location.index + 2)
-            val checkCastButtonInstruction =
-                getInstruction<BuilderInstruction21c>(constLeaveIdInstruction.location.index + 3)
+            // Instructions that inflate the "Leave Group" button, which the "Give Kudos" button is cloned from.
+            val constLeaveIdIndex = indexOfFirstLiteralInstructionOrThrow(leaveIdId.toLong())
+            val findViewByIdInstruction = getInstruction<BuilderInstruction35c>(constLeaveIdIndex + 1)
+            val fragmentRegister = findViewByIdInstruction.registerC
 
-            val buttonClassName = checkCastButtonInstruction.getReference<TypeReference>()!!.type
+            // The app packs this constructor tightly, so free registers must be found
+            // instead of assuming any are available.
+            val freeRegisters = getFreeRegisterProvider(constLeaveIdIndex, 3, fragmentRegister)
+            val viewRegister = freeRegisters.getFreeRegister4Bit()
+            val stateRegister = freeRegisters.getFreeRegister4Bit()
+            val methodNameRegister = freeRegisters.getFreeRegister4Bit()
 
             addInstructions(
-                constLeaveIdInstruction.location.index,
+                constLeaveIdIndex,
                 """
-                    ${constLeaveIdInstruction.opcode.name} v${constLeaveIdInstruction.registerA}, $kudosIdId
-                    ${findViewByIdInstruction.opcode.name} { v${findViewByIdInstruction.registerC}, v${findViewByIdInstruction.registerD} }, ${findViewByIdInstruction.reference}
-                    ${moveViewInstruction.opcode.name} v${moveViewInstruction.registerA}
-                    ${checkCastButtonInstruction.opcode.name} v${checkCastButtonInstruction.registerA}, ${checkCastButtonInstruction.reference}
-                    sget-object v0, ${getSingletonInstruction.reference}
-                    const-string v1, "${actionHandlerMethod.name}"
-                    new-instance v2, $GIVE_KUDOS_ON_CLICK_LISTENER_DESCRIPTOR
-                    invoke-direct { v2, p0, v0, v1 }, $GIVE_KUDOS_ON_CLICK_LISTENER_DESCRIPTOR-><init>(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;)V
-                    invoke-virtual { p3, v2 }, $buttonClassName->setOnClickListener($ON_CLICK_LISTENER_CLASS_DESCRIPTOR)V
+                    const v$viewRegister, $kudosIdId
+                    ${findViewByIdInstruction.opcode.name} { v$fragmentRegister, v$viewRegister }, ${findViewByIdInstruction.reference}
+                    move-result-object v$viewRegister
+                    sget-object v$stateRegister, $giveKudosStateReference
+                    const-string v$methodNameRegister, "${actionHandlerMethod.name}"
+                    invoke-static { v$viewRegister, p0, v$stateRegister, v$methodNameRegister }, $ATTACH_LISTENER_METHOD_DESCRIPTOR
                 """.trimIndent(),
             )
         }
     }
 }
-

--- a/patches/src/main/kotlin/app/morphe/patches/strava/groupkudos/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/strava/groupkudos/Fingerprints.kt
@@ -5,19 +5,8 @@
 package app.morphe.patches.strava.groupkudos
 
 import app.morphe.patcher.Fingerprint
-import app.morphe.patcher.literal
-
-/**
- * Method that renders the view states, one of which shows the "Give Kudos" dialog.
- *
- * Cannot be matched on the Kotlin parameter null check string "state",
- * because the app no longer contains those strings.
- */
-internal object ActionHandlerFingerprint : Fingerprint(
-    filters = listOf(
-        literal({ shakeToKudosStringId.toLong() }),
-    ),
-)
+import app.morphe.patches.shared.misc.mapping.ResourceType
+import app.morphe.patches.shared.misc.mapping.resourceLiteral
 
 internal object InitFingerprint : Fingerprint(
     name = "<init>",
@@ -26,5 +15,18 @@ internal object InitFingerprint : Fingerprint(
         "Lcom/strava/feed/view/modal/GroupTabFragment;",
         "Z",
         "Landroidx/fragment/app/FragmentManager;",
-    ),
+    )
+)
+
+/**
+ * Method that renders the view states, one of which shows the "Give Kudos" dialog.
+ *
+ * Cannot be matched on the Kotlin parameter null check string "state",
+ * because the app no longer contains those strings.
+ */
+internal object ActionHandlerFingerprint : Fingerprint(
+    classFingerprint = InitFingerprint,
+    filters = listOf(
+        resourceLiteral(ResourceType.STRING, "shake_to_kudos_dialog_title")
+    )
 )

--- a/patches/src/main/kotlin/app/morphe/patches/strava/groupkudos/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/strava/groupkudos/Fingerprints.kt
@@ -15,8 +15,3 @@ internal object InitFingerprint : Fingerprint(
         "Landroidx/fragment/app/FragmentManager;",
     ),
 )
-
-internal object ActionHandlerFingerprint : Fingerprint(
-    strings = listOf("state"),
-)
-

--- a/patches/src/main/kotlin/app/morphe/patches/strava/groupkudos/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/strava/groupkudos/Fingerprints.kt
@@ -5,6 +5,19 @@
 package app.morphe.patches.strava.groupkudos
 
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.literal
+
+/**
+ * Method that renders the view states, one of which shows the "Give Kudos" dialog.
+ *
+ * Cannot be matched on the Kotlin parameter null check string "state",
+ * because the app no longer contains those strings.
+ */
+internal object ActionHandlerFingerprint : Fingerprint(
+    filters = listOf(
+        literal({ shakeToKudosStringId.toLong() }),
+    ),
+)
 
 internal object InitFingerprint : Fingerprint(
     name = "<init>",

--- a/patches/src/main/kotlin/app/morphe/patches/strava/media/download/AddMediaDownloadPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/strava/media/download/AddMediaDownloadPatch.kt
@@ -11,22 +11,19 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLa
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.instructions
 import app.morphe.patcher.patch.bytecodePatch
-import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.util.smali.ExternalLabel
 import app.morphe.patches.shared.misc.mapping.ResourceType
 import app.morphe.patches.shared.misc.mapping.getResourceId
 import app.morphe.patches.shared.misc.mapping.resourceMappingPatch
 import app.morphe.patches.strava.misc.extension.sharedExtensionPatch
-import app.morphe.util.findMutableMethodOf
 import app.morphe.util.getReference
 import app.morphe.util.writeRegister
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction22c
-import com.android.tools.smali.dexlib2.iface.ClassDef
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import com.android.tools.smali.dexlib2.iface.reference.TypeReference
 
-private const val ACTION_CLASS_DESCRIPTOR = "Lcom/strava/bottomsheet/Action;"
+internal const val ACTION_CLASS_DESCRIPTOR = "Lcom/strava/bottomsheet/Action;"
 private const val MEDIA_CLASS_DESCRIPTOR = "Lcom/strava/photos/data/Media;"
 private const val MEDIA_DOWNLOAD_CLASS_DESCRIPTOR = "Lapp/morphe/extension/strava/AddMediaDownloadPatch;"
 
@@ -43,30 +40,9 @@ val addMediaDownloadPatch = bytecodePatch(
     )
 
     execute {
-        val fragmentClassDef = run {
-            var found: ClassDef? = null
-            classDefForEach { classDef ->
-                if (classDef.type.endsWith("/FullscreenMediaFragment;")) {
-                    found = classDef
-                }
-            }
-            found ?: throw PatchException("Could not find FullscreenMediaFragment class")
-        }
-
         // region Extend menu of `FullscreenMediaFragment` with actions.
 
-        // Method that builds the menu of the full-screen media viewer.
-        // Cannot be matched on the Kotlin parameter null check string "mediaType",
-        // because the app no longer contains those strings. It is the only method
-        // of the fragment that creates `Action` menu items.
-        val createAndShowFragmentMethod = fragmentClassDef.methods.firstOrNull { method ->
-            method.implementation?.instructions?.any { instruction ->
-                instruction.opcode == Opcode.NEW_INSTANCE &&
-                        instruction.getReference<TypeReference>()?.type == ACTION_CLASS_DESCRIPTOR
-            } == true
-        } ?: throw PatchException("Could not find the method that shows the media viewer menu")
-
-        mutableClassDefBy(fragmentClassDef).findMutableMethodOf(createAndShowFragmentMethod).apply {
+        CreateAndShowFragmentFingerprint.method.apply {
             val setTrueIndex = instructions.indexOfFirst { instruction ->
                 instruction.opcode == Opcode.IPUT_BOOLEAN
             }
@@ -114,7 +90,7 @@ val addMediaDownloadPatch = bytecodePatch(
         }
 
         // Handle "copy link" & "open link" & "download" actions.
-        HandleMediaActionFingerprint.match(fragmentClassDef).method.apply {
+        HandleMediaActionFingerprint.match(CreateAndShowFragmentFingerprint.originalClassDef).method.apply {
             // Call handler if action ID < 0 (= custom).
             val moveInstruction = instructions.first { instruction ->
                 instruction.opcode == Opcode.MOVE_RESULT

--- a/patches/src/main/kotlin/app/morphe/patches/strava/media/download/AddMediaDownloadPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/strava/media/download/AddMediaDownloadPatch.kt
@@ -17,6 +17,7 @@ import app.morphe.patches.shared.misc.mapping.ResourceType
 import app.morphe.patches.shared.misc.mapping.getResourceId
 import app.morphe.patches.shared.misc.mapping.resourceMappingPatch
 import app.morphe.patches.strava.misc.extension.sharedExtensionPatch
+import app.morphe.util.findMutableMethodOf
 import app.morphe.util.getReference
 import app.morphe.util.writeRegister
 import com.android.tools.smali.dexlib2.Opcode
@@ -54,7 +55,18 @@ val addMediaDownloadPatch = bytecodePatch(
 
         // region Extend menu of `FullscreenMediaFragment` with actions.
 
-        CreateAndShowFragmentFingerprint.match(fragmentClassDef).method.apply {
+        // Method that builds the menu of the full-screen media viewer.
+        // Cannot be matched on the Kotlin parameter null check string "mediaType",
+        // because the app no longer contains those strings. It is the only method
+        // of the fragment that creates `Action` menu items.
+        val createAndShowFragmentMethod = fragmentClassDef.methods.firstOrNull { method ->
+            method.implementation?.instructions?.any { instruction ->
+                instruction.opcode == Opcode.NEW_INSTANCE &&
+                        instruction.getReference<TypeReference>()?.type == ACTION_CLASS_DESCRIPTOR
+            } == true
+        } ?: throw PatchException("Could not find the method that shows the media viewer menu")
+
+        mutableClassDefBy(fragmentClassDef).findMutableMethodOf(createAndShowFragmentMethod).apply {
             val setTrueIndex = instructions.indexOfFirst { instruction ->
                 instruction.opcode == Opcode.IPUT_BOOLEAN
             }

--- a/patches/src/main/kotlin/app/morphe/patches/strava/media/download/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/strava/media/download/Fingerprints.kt
@@ -5,6 +5,21 @@
 package app.morphe.patches.strava.media.download
 
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.newInstance
+
+/**
+ * Method that builds the menu of the full-screen media viewer.
+ *
+ * Cannot be matched on the Kotlin parameter null check string "mediaType",
+ * because the app no longer contains those strings. It is the only method
+ * of the fragment that creates `Action` menu items.
+ */
+internal object CreateAndShowFragmentFingerprint : Fingerprint(
+    definingClass = "/FullscreenMediaFragment;",
+    filters = listOf(
+        newInstance(ACTION_CLASS_DESCRIPTOR),
+    ),
+)
 
 internal object HandleMediaActionFingerprint : Fingerprint(
     parameters = listOf(

--- a/patches/src/main/kotlin/app/morphe/patches/strava/media/download/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/strava/media/download/Fingerprints.kt
@@ -5,14 +5,6 @@
 package app.morphe.patches.strava.media.download
 
 import app.morphe.patcher.Fingerprint
-import com.android.tools.smali.dexlib2.AccessFlags
-
-internal object CreateAndShowFragmentFingerprint : Fingerprint(
-    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
-    returnType = "V",
-    parameters = listOf("L"),
-    strings = listOf("mediaType"),
-)
 
 internal object HandleMediaActionFingerprint : Fingerprint(
     parameters = listOf(
@@ -20,4 +12,3 @@ internal object HandleMediaActionFingerprint : Fingerprint(
         "Lcom/strava/bottomsheet/BottomSheetItem;",
     ),
 )
-


### PR DESCRIPTION
### Description

Fixes `Add 'Give Kudos' button to 'Group Activity'` and `Add media download` on Strava `477.14`, and bumps the recommended version from `473.11`.

Three breakages:

1. **Fingerprints no longer match.** R8 stopped emitting Kotlin parameter-name strings for null checks, so matching on `"state"` and `"mediaType"` finds nothing. Both target methods are now found by structure instead: the kudos action handler by its `shake_to_kudos_dialog_title` literal, the media viewer menu builder as the only fragment method constructing `Action` items.

2. **The kudos injection corrupted its target.** `osj.<init>` is now compiled with six registers, so the hardcoded `v0`/`v1`/`v2` overwrote `this` and two live parameters, and `invoke-virtual { p3, … }` only worked because `v5` incidentally held the button after register reuse. Registers now come from `getFreeRegisterProvider`, and `setOnClickListener` moved into the extension as `GiveKudosOnClickListener.attach`, which needs one fewer register and drops the dependency on the button's concrete type.

3. **Removed string resources.** `yis_2024_local_save_{image,video}_success` are gone, leaving the download toasts blank. Replaced with `animated_content_save_{image,video}_success`.

The media download patch's bytecode edits themselves are unchanged and still valid.

Closes #92

### Additional context

The version bump covers all Strava patches: the anchors used by the other six are unchanged in `477.14`.

May also fix #75 (group kudos button doing nothing), which is a plausible symptom of the register corruption, though not verified on that version.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [ ] Tested on **experimental** supported versions (Optional)

`477.14` is the only supported version. Both patches apply with no `--force`, and both were tested on-device: the group tab shows Leave Group and Give Kudos side by side and the dialog opens, and the fullscreen media menu shows Copy link / Open in browser / Download with downloads working.

### AI disclosure

Debugging, fix and write-up all done with Claude Code. Testing was manual.