### PR TITLE
fix(Google Photos): Handle GmsCore avatar auth consent

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/GmsCoreSupportPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/GmsCoreSupportPatch.java
@@ -153,18 +153,11 @@ public class GmsCoreSupportPatch {
             }
 
             // Google Photos' current OneGoogle account UI asks newer Play Services APIs for the
-            // profile image. Keep this compatibility bridge strictly scoped to Photos so shared
-            // GmsCore users are unaffected even if they expose similar OneGoogle resources.
+            // profile image. Keep this compatibility bridge strictly scoped to Photos. The bridge
+            // performs its own tolerant resource discovery, so installation must not depend on a
+            // single OneGoogle resource ID that may be renamed between Photos versions.
             if (GOOGLE_PHOTOS_PACKAGE_NAME.equals(getOriginalPackageName())) {
-                int avatarViewId = context.getResources().getIdentifier(
-                        "og_apd_internal_image_view", "id", context.getPackageName());
-                if (avatarViewId == 0) {
-                    avatarViewId = context.getResources().getIdentifier(
-                            "og_apd_internal_image_view", "id", GOOGLE_PHOTOS_PACKAGE_NAME);
-                }
-                if (avatarViewId != 0) {
-                    GooglePhotosAccountAvatar.install(context);
-                }
+                GooglePhotosAccountAvatar.install(context);
             }
 
             // Check if GmsCore is whitelisted from battery optimizations.

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/GooglePhotosAccountAvatar.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/GooglePhotosAccountAvatar.java
@@ -8,6 +8,7 @@ package app.morphe.extension.shared.patches;
 import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.accounts.AccountManagerFuture;
+import android.accounts.OperationCanceledException;
 import android.app.Activity;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
@@ -44,6 +45,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -88,6 +90,8 @@ final class GooglePhotosAccountAvatar {
             "morphe_google_photos_account_avatar";
 
     private static final AtomicReference<String> FETCHING_ACCOUNT = new AtomicReference<>();
+    private static final Set<String> CANCELLED_AUTH_ACCOUNTS =
+            Collections.synchronizedSet(new HashSet<>());
     private static final AtomicBoolean WINDOW_SCAN_ERROR_LOGGED = new AtomicBoolean();
     private static final Map<ImageView, String> SCHEDULED_TOOLBAR_AVATARS = new WeakHashMap<>();
     private static final Map<View, String> SCHEDULED_ACCOUNT_SHEETS = new WeakHashMap<>();
@@ -289,61 +293,30 @@ final class GooglePhotosAccountAvatar {
 
     private static void requestProfileToken(Activity activity, View root, Account account) {
         final String accountName = account.name;
+        final String accountKey = accountName.toLowerCase(Locale.ROOT);
         if (avatar != null && sameAccount(accountName, avatarAccountName)) return;
+        if (CANCELLED_AUTH_ACCOUNTS.contains(accountKey)) return;
         if (!FETCHING_ACCOUNT.compareAndSet(null, accountName)) return;
 
         try {
             Logger.printInfo(() -> "Requesting the Google Photos avatar token");
 
             Bundle options = new Bundle();
-            options.putString("androidPackageName", activity.getPackageName());
-            AccountManagerFuture<Bundle> future = AccountManager.get(activity).getAuthToken(
+            options.putString(AccountManager.KEY_ANDROID_PACKAGE_NAME, activity.getPackageName());
+            AccountManager.get(activity).getAuthToken(
                     account,
                     PROFILE_TOKEN_TYPE,
                     options,
-                    false,
-                    null,
+                    activity,
+                    future -> handleProfileTokenResult(
+                            activity,
+                            root,
+                            accountName,
+                            accountKey,
+                            future
+                    ),
                     null
             );
-
-            Utils.runOnBackgroundThread(() -> {
-                boolean refreshDifferentAccount = false;
-                try {
-                    Bundle result = future.getResult();
-                    String token = result.getString(AccountManager.KEY_AUTHTOKEN);
-                    if (token == null || token.isEmpty()) {
-                        throw new IllegalStateException("GmsCore returned no profile token");
-                    }
-
-                    Bitmap downloadedAvatar = downloadAvatar(token);
-                    if (downloadedAvatar == null) {
-                        throw new IllegalStateException("Google user-info returned no avatar");
-                    }
-
-                    writeCachedAvatar(activity, accountName, downloadedAvatar);
-
-                    if (sameAccount(accountName, selectedAccountName)) {
-                        avatar = downloadedAvatar;
-                        avatarAccountName = accountName;
-                        Logger.printInfo(() -> "Google Photos account avatar loaded");
-                        Utils.runOnMainThread(() -> applyAvatar(activity, root));
-                    } else {
-                        refreshDifferentAccount = selectedAccountName != null;
-                    }
-                } catch (Exception exception) {
-                    Logger.printException(
-                            () -> "Could not load the Google Photos account avatar",
-                            exception
-                    );
-                    refreshDifferentAccount = selectedAccountName != null
-                            && !sameAccount(accountName, selectedAccountName);
-                } finally {
-                    FETCHING_ACCOUNT.compareAndSet(accountName, null);
-                    if (refreshDifferentAccount) {
-                        Utils.runOnMainThread(() -> refresh(activity, root));
-                    }
-                }
-            });
         } catch (Exception exception) {
             FETCHING_ACCOUNT.compareAndSet(accountName, null);
             Logger.printException(
@@ -351,6 +324,76 @@ final class GooglePhotosAccountAvatar {
                     exception
             );
         }
+    }
+
+    private static void handleProfileTokenResult(
+            Activity activity,
+            View root,
+            String accountName,
+            String accountKey,
+            AccountManagerFuture<Bundle> future
+    ) {
+        final String token;
+        try {
+            Bundle result = future.getResult();
+            token = result.getString(AccountManager.KEY_AUTHTOKEN);
+            if (token == null || token.isEmpty()) {
+                throw new IllegalStateException("GmsCore returned no profile token");
+            }
+            CANCELLED_AUTH_ACCOUNTS.remove(accountKey);
+        } catch (OperationCanceledException exception) {
+            // Morphe returns a consent Intent when this OAuth service has not been permitted yet.
+            // The Activity overload above lets AccountManager launch it and resume this callback.
+            // If the user denies/cancels, suppress repeated prompts until the process restarts.
+            CANCELLED_AUTH_ACCOUNTS.add(accountKey);
+            FETCHING_ACCOUNT.compareAndSet(accountName, null);
+            Logger.printInfo(() -> "Google Photos avatar permission was not granted");
+            return;
+        } catch (Exception exception) {
+            FETCHING_ACCOUNT.compareAndSet(accountName, null);
+            Logger.printException(
+                    () -> "Could not obtain the Google Photos profile token",
+                    exception
+            );
+            if (selectedAccountName != null
+                    && !sameAccount(accountName, selectedAccountName)) {
+                Utils.runOnMainThread(() -> refresh(activity, root));
+            }
+            return;
+        }
+
+        Utils.runOnBackgroundThread(() -> {
+            boolean refreshDifferentAccount = false;
+            try {
+                Bitmap downloadedAvatar = downloadAvatar(token);
+                if (downloadedAvatar == null) {
+                    throw new IllegalStateException("Google user-info returned no avatar");
+                }
+
+                writeCachedAvatar(activity, accountName, downloadedAvatar);
+
+                if (sameAccount(accountName, selectedAccountName)) {
+                    avatar = downloadedAvatar;
+                    avatarAccountName = accountName;
+                    Logger.printInfo(() -> "Google Photos account avatar loaded");
+                    Utils.runOnMainThread(() -> applyAvatar(activity, root));
+                } else {
+                    refreshDifferentAccount = selectedAccountName != null;
+                }
+            } catch (Exception exception) {
+                Logger.printException(
+                        () -> "Could not load the Google Photos account avatar",
+                        exception
+                );
+                refreshDifferentAccount = selectedAccountName != null
+                        && !sameAccount(accountName, selectedAccountName);
+            } finally {
+                FETCHING_ACCOUNT.compareAndSet(accountName, null);
+                if (refreshDifferentAccount) {
+                    Utils.runOnMainThread(() -> refresh(activity, root));
+                }
+            }
+        });
     }
 
     @Nullable


### PR DESCRIPTION
Summary

Follow-up to #114 for Google Photos account avatars with Morphe GmsCore.

- Use the foreground "AccountManager#getAuthToken(..., Activity, ...)" flow so authenticator consent intents are launched and completed instead of being treated as a missing token.
- Keep the avatar request locked while interactive consent is in progress.
- Suppress repeated consent prompts for the same account after a cancellation or denial until the process restarts.
- Use "AccountManager.KEY_ANDROID_PACKAGE_NAME" instead of the raw key string.
- Install the Google Photos avatar bridge without gating it on the single "og_apd_internal_image_view" resource ID, since the bridge already performs tolerant resource discovery internally.

Why

Morphe GmsCore can legitimately return "AccountManager.KEY_INTENT" when an OAuth service has not yet been permitted.

The previous implementation used the non-interactive token request and only consumed "KEY_AUTHTOKEN". As a result, first-time authorization could fail with "GmsCore returned no profile token" instead of launching the required consent screen.

The avatar bridge was also skipped entirely when "og_apd_internal_image_view" could not be resolved, making the implementation fragile across Google Photos versions.

Scope

This change is intentionally limited to the Google Photos avatar compatibility bridge.

It does not change the account type, OAuth scopes, or the existing per-account avatar cache.