### PR TITLE
fix(Google Photos): Fix avatar OAuth scope, JSON parser, and error logging

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/GooglePhotosAccountAvatar.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/GooglePhotosAccountAvatar.java
@@ -29,9 +29,7 @@ import android.widget.ImageView;
 
 import androidx.annotation.Nullable;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import org.json.JSONObject;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
@@ -71,7 +69,7 @@ final class GooglePhotosAccountAvatar {
     private static final String ACCOUNT_TYPE = "app.revanced";
     private static final String RESOURCE_PACKAGE_NAME = "com.google.android.apps.photos";
     private static final String PROFILE_TOKEN_TYPE =
-            "oauth2:openid profile https://www.googleapis.com/auth/mobileapps.native "
+            "oauth2:openid https://www.googleapis.com/auth/mobileapps.native "
                     + "https://www.googleapis.com/auth/photos.native";
     private static final String USER_INFO_URL =
             "https://www.googleapis.com/oauth2/v3/userinfo";
@@ -351,9 +349,8 @@ final class GooglePhotosAccountAvatar {
             return;
         } catch (Exception exception) {
             FETCHING_ACCOUNT.compareAndSet(accountName, null);
-            Logger.printException(
-                    () -> "Could not obtain the Google Photos profile token",
-                    exception
+            Logger.printInfo(
+                    () -> "Could not obtain the Google Photos profile token: " + exception.getMessage()
             );
             if (selectedAccountName != null
                     && !sameAccount(accountName, selectedAccountName)) {
@@ -381,9 +378,8 @@ final class GooglePhotosAccountAvatar {
                     refreshDifferentAccount = selectedAccountName != null;
                 }
             } catch (Exception exception) {
-                Logger.printException(
-                        () -> "Could not load the Google Photos account avatar",
-                        exception
+                Logger.printInfo(
+                        () -> "Could not load the Google Photos account avatar: " + exception.getMessage()
                 );
                 refreshDifferentAccount = selectedAccountName != null
                         && !sameAccount(accountName, selectedAccountName);
@@ -407,16 +403,20 @@ final class GooglePhotosAccountAvatar {
                 throw new IllegalStateException("Google user-info HTTP status " + status);
             }
 
-            JsonObject response;
+            StringBuilder jsonBuilder = new StringBuilder();
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(
                     userInfoConnection.getInputStream(), StandardCharsets.UTF_8))) {
-                response = JsonParser.parseReader(reader).getAsJsonObject();
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    jsonBuilder.append(line);
+                }
             }
 
-            JsonElement picture = response.get("picture");
-            if (picture == null || picture.isJsonNull()) return null;
+            JSONObject response = new JSONObject(jsonBuilder.toString());
+            String pictureUrl = response.optString("picture", null);
+            if (pictureUrl == null || pictureUrl.isEmpty()) return null;
 
-            HttpURLConnection imageConnection = openConnection(picture.getAsString());
+            HttpURLConnection imageConnection = openConnection(pictureUrl);
             try {
                 if (imageConnection.getResponseCode() != HttpURLConnection.HTTP_OK) return null;
                 try (InputStream stream = new BufferedInputStream(imageConnection.getInputStream())) {

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/Utils.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/Utils.java
@@ -1190,7 +1190,7 @@ public class Utils {
     public static <T, V> Map<T, V> createSizeRestrictedMap(int maxSize) {
         return new LinkedHashMap<>(2 * maxSize) {
             @Override
-            protected boolean removeEldestEntry(Entry eldest) {
+            protected boolean removeEldestEntry(Map.Entry<T, V> eldest) {
                 return size() > maxSize;
             }
         };


### PR DESCRIPTION
### Summary
Follow-up to #118 for Google Photos account avatars with Morphe / MicroG-RE.

- **Remove \`profile\` scope from \`PROFILE_TOKEN_TYPE\`**: The official Google Photos OAuth client is only registered for \`openid https://www.googleapis.com/auth/mobileapps.native https://www.googleapis.com/auth/photos.native\`. Requesting \`profile\` caused Google's auth server to reject the token request with \`RESTRICTED_CLIENT: Unregistered scope(s) in the request: profile\`. The \`openid\` scope alone is sufficient for the \`userinfo\` endpoint to return the \`picture\` URL.
- **Use native \`org.json.JSONObject\` instead of Gson**: Google Photos does not include unbundled Gson classes at runtime, which previously caused a \`NoClassDefFoundError: JsonParser\` crash on background threads. Using the standard Android framework \`JSONObject\` ensures zero external dependencies and fast parsing.
- **Downgrade avatar fetch/token errors to INFO level**: Per review feedback on #118, avoid popping intrusive error toasts when an account has no custom avatar or when the device is offline.
- **Fix \`removeEldestEntry\` signature in \`Utils.java\`** (\`Map.Entry<T, V>\`).

### Verification
- Built and tested on device (Pixel 6 Pro).
- Verified Google Photos successfully displays the user profile avatar in both the top toolbar and the OneGoogle account sheet.