### PR TITLE
bump(Pixiv): Add support for `6.196.0`

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/pixiv/ads/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/pixiv/ads/Fingerprints.kt
@@ -10,8 +10,13 @@ import com.android.tools.smali.dexlib2.AccessFlags
 internal object ShouldShowAdsFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "Z",
+    parameters = listOf(),
     custom = { methodDef, classDef ->
-        classDef.type.endsWith("AdUtils;") && methodDef.name == "shouldShowAds"
+        // Pixiv 6.196.0 obfuscates AdUtils to the default-package class `zc`
+        // and renames shouldShowAds() to a(). Keep the original signature so
+        // the patch remains usable with the previously supported release.
+        (classDef.type.endsWith("AdUtils;") && methodDef.name == "shouldShowAds") ||
+            (classDef.type == "Lzc;" && methodDef.name == "a")
     },
 )
 

--- a/patches/src/main/kotlin/app/morphe/patches/pixiv/ads/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/pixiv/ads/Fingerprints.kt
@@ -1,22 +1,37 @@
 /*
+ * Copyright 2026 De-Vanced
+ * https://github.com/RookieEnough/De-Vanced
+ *
  * Forked from:
  * https://gitlab.com/ReVanced/revanced-patches/-/blob/main/patches/src/main/kotlin/app/revanced/patches/pixiv/ads/Fingerprints.kt
  */
 package app.morphe.patches.pixiv.ads
 
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.InstructionLocation.MatchAfterWithin
+import app.morphe.patcher.methodCall
 import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
 
-internal object ShouldShowAdsFingerprint : Fingerprint(
+internal object ShouldShowAdsLegacyFingerprint : Fingerprint(
+    definingClass = "/AdUtils;",
+    name = "shouldShowAds",
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "Z",
-    parameters = listOf(),
-    custom = { methodDef, classDef ->
-        // Pixiv 6.196.0 obfuscates AdUtils to the default-package class `zc`
-        // and renames shouldShowAds() to a(). Keep the original signature so
-        // the patch remains usable with the previously supported release.
-        (classDef.type.endsWith("AdUtils;") && methodDef.name == "shouldShowAds") ||
-            (classDef.type == "Lzc;" && methodDef.name == "a")
-    },
 )
 
+internal object ShouldShowAdsFingerprint : Fingerprint(
+    name = "invokeSuspend",
+    filters = listOf(
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            smali = "Lcom/applovin/mediation/ads/MaxInterstitialAd;->isReady()Z"
+        ),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            returnType = "Z",
+            parameters = listOf(),
+            location = MatchAfterWithin(20)
+        )
+    )
+)

--- a/patches/src/main/kotlin/app/morphe/patches/pixiv/ads/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/pixiv/ads/HideAdsPatch.kt
@@ -1,11 +1,14 @@
 /*
+ * Copyright 2026 De-Vanced
+ * https://github.com/RookieEnough/De-Vanced
+ *
  * Forked from:
  * https://gitlab.com/ReVanced/revanced-patches/-/blob/main/patches/src/main/kotlin/app/revanced/patches/pixiv/ads/HideAdsPatch.kt
  */
 package app.morphe.patches.pixiv.ads
 
-import app.morphe.patches.shared.compat.AppCompatibilities
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.shared.compat.AppCompatibilities
 import app.morphe.util.returnEarly
 
 @Suppress("unused")
@@ -15,7 +18,13 @@ val hideAdsPatch = bytecodePatch(
     compatibleWith(AppCompatibilities.PIXIV)
 
     execute {
-        ShouldShowAdsFingerprint.method.returnEarly(false)
+        val method = if (packageMetadata.versionName == "6.141.1") {
+            ShouldShowAdsLegacyFingerprint.method
+        } else {
+            ShouldShowAdsFingerprint.instructionMatches.first().getMethodCalled()
+        }
+
+        method.returnEarly(false)
     }
 }
 

--- a/patches/src/main/kotlin/app/morphe/patches/pixiv/ads/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/pixiv/ads/HideAdsPatch.kt
@@ -12,7 +12,7 @@ import app.morphe.util.returnEarly
 val hideAdsPatch = bytecodePatch(
     name = "Hide ads",
 ) {
-    compatibleWith(AppCompatibilities.PIXIV_ADS)
+    compatibleWith(AppCompatibilities.PIXIV)
 
     execute {
         ShouldShowAdsFingerprint.method.returnEarly(false)

--- a/patches/src/main/kotlin/app/morphe/patches/pixiv/ads/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/pixiv/ads/HideAdsPatch.kt
@@ -12,7 +12,7 @@ import app.morphe.util.returnEarly
 val hideAdsPatch = bytecodePatch(
     name = "Hide ads",
 ) {
-    compatibleWith(AppCompatibilities.PIXIV)
+    compatibleWith(AppCompatibilities.PIXIV_ADS)
 
     execute {
         ShouldShowAdsFingerprint.method.returnEarly(false)

--- a/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
@@ -124,7 +124,10 @@ internal object AppCompatibilities {
         name = "Pixiv",
         packageName = "jp.pxv.android",
         appIconColor = 0x0096FA,
-        targets = listOf(AppTarget("6.196.0")),
+        targets = listOf(
+            AppTarget("6.196.0"),
+            AppTarget("6.141.1")
+        )
     )
 
     val CRICBUZZ = Compatibility(

--- a/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
@@ -124,7 +124,7 @@ internal object AppCompatibilities {
         name = "Pixiv",
         packageName = "jp.pxv.android",
         appIconColor = 0x0096FA,
-        targets = listOf(AppTarget("6.141.1")),
+        targets = listOf(AppTarget("6.196.0")),
     )
 
     val CRICBUZZ = Compatibility(


### PR DESCRIPTION
Updates the Pixiv ad fingerprint for the code introduced in version 6.196.0

The newer version moved the ad decision method to the obfuscated method Lzc;->a()Z.

Tested with:

Pixiv 6.196.0 (68251)
Morphe Manager 1.30.0
Morphe Patcher 1.13.0
STRIP_FAST bytecode mode

The Hide Ads patch applied successfully and the patched method returns false.