### PR TITLE
bump(Google Photos): Add support for `7.92.0.977185651`

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/googlephotos/misc/gms/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/googlephotos/misc/gms/Fingerprints.kt
@@ -24,5 +24,8 @@ internal object HomeActivityOnCreateFingerprint : Fingerprint(
 internal object IsGooglePlayServicesAvailableFingerprint : Fingerprint(
     returnType = "I",
     parameters = listOf("L", "I"),
-    strings = listOf("Google Play Services not available"),
+    strings = listOf(
+        "com.google.android.gms.version",
+        "com.google.app.id",
+    ),
 )

--- a/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
@@ -113,6 +113,7 @@ internal object AppCompatibilities {
         packageName = "com.google.android.apps.photos",
         appIconColor = 0xFC3F3C,
         targets = listOf(
+            AppTarget(version = "7.92.0.977185651"),
             AppTarget(version = "7.80.0.929302933")
         )
     )


### PR DESCRIPTION
### Description

Fix the Google Photos Google Play Services availability fingerprint used by the GmsCore support patch.

The current `IsGooglePlayServicesAvailableFingerprint` relies on:

```text
Google Play Services not available
```

This string no longer matches the target availability method in recent Google Photos versions.

For debugging, I temporarily changed:

```kotlin
IsGooglePlayServicesAvailableFingerprint.methodOrNull?.returnEarly(0)
```

to:

```kotlin
IsGooglePlayServicesAvailableFingerprint.method.returnEarly(0)
```

On Google Photos `7.80.0.929302933`, this caused Morphe to explicitly fail with:

```text
Failed to match the fingerprint:
app.morphe.patches.googlephotos.misc.gms.IsGooglePlayServicesAvailableFingerprint
```

The fingerprint was updated to use the Google Play Services metadata strings:

```kotlin
strings = listOf(
    "com.google.android.gms.version",
    "com.google.app.id",
)
```

These anchors successfully locate the `(Context, int) -> int` Google Play Services availability check.

The production patch remains unchanged and continues to use:

```kotlin
methodOrNull?.returnEarly(0)
```

Refs #66

### Additional context

The updated fingerprint was tested successfully on a non-root Google Pixel 7a running Android 17 / API 37 with:

* Morphe Manager `1.30.0`
* Morphe Patcher `1.13.0`
* De-Vanced Patches `1.4.0` local build
* Google Photos `7.80.0.929302933`
* Google Photos `7.92.0.977185651`

After this change:

* Google Photos patches successfully.
* Google account/login works.
* `Collections → Places` opens successfully.
* The previous unsupported Google Play Services error no longer appears.
* Maps-backed views render through the current GmsCore/OpenFreeMap setup.

There are still separate Places-related behaviors that are not addressed by this PR:

* Place entries show `0 photos`.
* Some place entries contain photos that do not appear to belong to that location.

These appear to be separate GmsCore/Maps compatibility issues and are not part of this fingerprint fix.

### Test results

* [ ] Tested on both the **minimum** and **maximum** supported versions
* [ ] Tested on **experimental** supported versions (Optional)

Additional tested versions:

* [x] Google Photos `7.80.0.929302933`
* [x] Google Photos `7.92.0.977185651`
* [x] Tested on a non-root device
* [x] Confirmed `Collections → Places` opens without the Google Play Services unsupported-device error
